### PR TITLE
Filter past one time reminders in search API

### DIFF
--- a/src/database/repository.interfaces/general/reminder.schedule.repo.interface.ts
+++ b/src/database/repository.interfaces/general/reminder.schedule.repo.interface.ts
@@ -24,4 +24,6 @@ export interface IReminderScheduleRepo {
 
     markAsAcknowledged(id: string): Promise<boolean>;
 
+    isReminderHasFutureSchedule(reminderId: string): Promise<boolean>;
+
 }

--- a/src/database/sql/sequelize/repositories/general/reminder.schedule.repo.ts
+++ b/src/database/sql/sequelize/repositories/general/reminder.schedule.repo.ts
@@ -152,6 +152,23 @@ export class ReminderScheduleRepo implements IReminderScheduleRepo {
         }
     };
 
+    isReminderHasFutureSchedule = async (reminderId: string): Promise<boolean> => {
+        try {
+            const schedules = await ReminderSchedule.findAll({
+                where : {
+                    ReminderId : reminderId,
+                    Schedule   : {
+                        [Op.gte] : new Date(),
+                    }
+                },
+            });
+            return schedules.length > 0 ? true : false;
+        } catch (error) {
+            Logger.instance().log(error.message);
+            throw new ApiError(500, error.message);
+        }
+    };
+
     deleteAllSchedulesForUser = async (userId: string): Promise<number> => {
         try {
             const schedulesDeleted = await ReminderSchedule.destroy({


### PR DESCRIPTION
### Related issue
  - *Filter past one time reminders in search API*

  
### List of changes
  - *Added function isReminderHasFutureSchedule in reminder scedule repo*
  - *Added a filter on search function in reminder.service file*

### Database migration/schema changes (if any)
- *Not Required*

### Self review checklist
  - [x] Confirm that the changes made by you meet the resolution criteria and nothing else.
  - [x] Ran all the tests locally to check that you have not introduced any new regression.
  - [x] If there are any failing tests, you have already fixed them. If not 
  - [x] Followed coding and styling guidelines.
  - [x] Made sure the changes are is not overly complex, unreadable and unnecessarily smart. Simplicity wins!
  - [x] Made sure the comments are not too verbose and not to cryptic.
  - [x] Made sure the code metrics are not deteriorated.
  - [x] Made sure you have updated (if necessary)-
    - [ ] Documentation
    - [ ] Translation
    - [ ] Tests/test data
    - [ ] Postman collection
    - [ ] Version
       
### Additional info (if any)
- *Add anything you feel worth mentioning...*

### screensshots (if any)

Original | Updated
:------------------------:|-------------------------------|
** Original screenshot ** | ** Updated screenshot **|
